### PR TITLE
Pass `error` through to the `errorHandler` 

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -17,7 +17,7 @@ export default class consumer {
   // See `types/main.d.ts` for what these do
   recordHandler?: (streamRecord: StreamRecord) => Promise<void>
   batchHandler?: (streamRecords: StreamRecord[]) => Promise<void>
-  errorHandler?: (streamRecord: StreamRecord) => Promise<void>
+  errorHandler?: (streamRecord: StreamRecord, error: unknown) => Promise<void>
 
   constructor (options: ConsumerOptions) {
     this.redisClient = options.redisClient
@@ -76,7 +76,7 @@ export default class consumer {
                 handledError = true
                 await this.ackIDs(ids)
                 if (this.errorHandler) {
-                  await this.errorHandler(record)
+                  await this.errorHandler(record, error)
                 }
                 break
               }
@@ -135,7 +135,7 @@ export default class consumer {
                   handledError = true
                   await this.ackIDs(ids)
                   if (this.errorHandler) {
-                    await this.errorHandler(record)
+                    await this.errorHandler(record, error)
                   }
                   break
                 }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -51,7 +51,7 @@ export interface ConsumerOptions {
   /**
    * Function called on the record that threw an error, after all previously processes messages are acknowledged
    */
-  errorHandler?: (streamRecord: StreamRecord) => Promise<void>
+  errorHandler?: (streamRecord: StreamRecord, error: unknown) => Promise<void>
 }
 
 /**


### PR DESCRIPTION
Currently if an error is thrown during the processing of an event in the `recordHandler`, this gets caught but not forwarded to the `errorHandler`. It would be useful to have this data so the actual error can be logged, processed etc. 